### PR TITLE
Remove 'encoding' argument from json.load call

### DIFF
--- a/LinodeDynDNS.py
+++ b/LinodeDynDNS.py
@@ -102,7 +102,7 @@ except Exception as excp:
 
 def execute(action, parameters):
 	# Execute a query and return a Python dictionary.
-	uri = "{0}&action={1}".format(API.format(KEY), action)
+	uri = "{0}&api_action={1}".format(API.format(KEY), action)
 	if parameters and len(parameters) > 0:
 		uri = "{0}&{1}".format(uri, urlencode(parameters))
 	if DEBUG:

--- a/LinodeDynDNS.py
+++ b/LinodeDynDNS.py
@@ -113,7 +113,7 @@ def execute(action, parameters):
 		print(headers, end="")
 		print(open(file).read())
 		print()
-	json = load(open(file), encoding="utf-8")
+	json = load(open(file))
 	if len(json["ERRORARRAY"]) > 0:
 		err = json["ERRORARRAY"][0]
 		raise Exception("Error {0}: {1}".format(int(err["ERRORCODE"]),


### PR DESCRIPTION
In Python 3.9.7, the deprecated 'encoding' argument in json.load now throws an error. Removing it entirely gets the code working, again.